### PR TITLE
Fix: Improve dark mode contrast on transaction page

### DIFF
--- a/src/lib/Transactions/TradeTransaction.svelte
+++ b/src/lib/Transactions/TradeTransaction.svelte
@@ -35,13 +35,13 @@
         font-weight: 600;
         line-height: 1em;
         margin: 0.1em;
-        color: #2E7D32;
+        color: var(--blueOne);
         font-size: 0.9rem;
     }
 
     .currentOwner {
         font-style: italic;
-        color: #666;
+        color: var(--g555);
         font-size: 0.7em;
         font-weight: normal;
     }

--- a/src/lib/Transactions/TransactionMove.svelte
+++ b/src/lib/Transactions/TransactionMove.svelte
@@ -76,7 +76,7 @@
 	}
 
 	.originalOwner {
-		color: #aaa;
+		color: var(--g555);
 		font-style: italic;
 	}
 

--- a/src/lib/Transactions/WaiverTransaction.svelte
+++ b/src/lib/Transactions/WaiverTransaction.svelte
@@ -80,7 +80,7 @@
 
     .currentOwner {
         font-style: italic;
-        color: #666;
+        color: var(--g555);
         font-weight: normal;
     }
 
@@ -115,12 +115,12 @@
         text-align: center;
         font-weight: 500;
         margin-top: 6px;
-        color: #333;
+        color: var(--g111);
     }
 
     .playerInfo {
         font-size: 0.7em;
-        color: #666;
+        color: var(--g555);
         line-height: 1em;
         text-align: center;
         margin-top: 4px;


### PR DESCRIPTION
Replaced hardcoded text colors with CSS variables in the transaction-related components to ensure proper contrast in dark mode.